### PR TITLE
option to use installed tblis

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,12 @@ Install
 ```
 pip install pyscf-tblis
 ```
+
+This will compile and install TBLIS in addition to the wrapper. If you already
+have TBLIS installed on your system (e.g. if you installed the conda-forge
+package) you can run
+
+```
+CMAKE_CONFIGURE_ARGS="-DVENDOR_TBLIS=off" pip install . --no-deps
+```
+

--- a/pyscf/tblis_einsum/CMakeLists.txt
+++ b/pyscf/tblis_einsum/CMakeLists.txt
@@ -46,21 +46,48 @@ endif ()
 set(C_LINK_TEMPLATE "<CMAKE_C_COMPILER> <CMAKE_SHARED_LIBRARY_C_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>")
 set(CXX_LINK_TEMPLATE "<CMAKE_CXX_COMPILER> <CMAKE_SHARED_LIBRARY_CXX_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>")
 
-include(ExternalProject)
-ExternalProject_Add(libtblis
-  GIT_REPOSITORY https://github.com/devinamatthews/tblis.git
-  GIT_TAG master
-  PREFIX ${PROJECT_BINARY_DIR}/deps
-  INSTALL_DIR ${PROJECT_SOURCE_DIR}
-  CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --libdir=<INSTALL_DIR>
-          --disable-static CXX=${CMAKE_CXX_COMPILER}
-)
-include_directories(${PROJECT_SOURCE_DIR}/include)
-link_directories(${PROJECT_SOURCE_DIR})
-
 add_library(tblis_einsum SHARED as_einsum.cxx)
+
+option(VENDOR_TBLIS "Download and build tblis" on)
 set_target_properties(tblis_einsum PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}
   COMPILE_FLAGS "-std=c++11")
-target_link_libraries(tblis_einsum tblis)
-add_dependencies(tblis_einsum libtblis)
+
+
+if(VENDOR_TBLIS)
+
+  include(ExternalProject)
+  ExternalProject_Add(libtblis
+    GIT_REPOSITORY https://github.com/devinamatthews/tblis.git
+    GIT_TAG master
+    PREFIX ${PROJECT_BINARY_DIR}/deps
+    INSTALL_DIR ${PROJECT_SOURCE_DIR}
+    CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --libdir=<INSTALL_DIR>
+            --disable-static CXX=${CMAKE_CXX_COMPILER}
+  )
+  include_directories(${PROJECT_SOURCE_DIR}/include)
+  link_directories(${PROJECT_SOURCE_DIR})
+  target_link_libraries(tblis_einsum tblis)
+  add_dependencies(tblis_einsum libtblis)
+
+else()
+
+  include(FindPackageHandleStandardArgs)
+  find_library(TBLIS_LIBRARY NAMES libtblis tblis)
+  find_path(TBLIS_INCLUDE_DIR NAMES tblis/tblis.h)
+  find_package_handle_standard_args(tblis REQUIRED_VARS TBLIS_LIBRARY TBLIS_INCLUDE_DIR HANDLE_COMPONENTS)
+
+  if (tblis_FOUND)
+    mark_as_advanced(TBLIS_INCLUDE_DIR)
+    mark_as_advanced(TBLIS_LIBRARY)
+  endif()
+
+  if (tblis_FOUND AND NOT TARGET tblis::tblis)
+    add_library(tblis::tblis IMPORTED)
+    set_property(TARGET tblis::tblis PROPERTY IMPORTED_LOCATION ${TBLIS_LIBRARY})
+    target_include_directories(tblis::tblis INTERFACE ${TBLIS_INCLUDE_DIR})
+  endif()
+
+  target_link_libraries(tblis_einsum tblis::tblis)
+
+endif()

--- a/pyscf/tblis_einsum/CMakeLists.txt
+++ b/pyscf/tblis_einsum/CMakeLists.txt
@@ -83,7 +83,7 @@ else()
   endif()
 
   if (tblis_FOUND AND NOT TARGET tblis::tblis)
-    add_library(tblis::tblis IMPORTED)
+    add_library(tblis::tblis IMPORTED SHARED)
     set_property(TARGET tblis::tblis PROPERTY IMPORTED_LOCATION ${TBLIS_LIBRARY})
     target_include_directories(tblis::tblis INTERFACE ${TBLIS_INCLUDE_DIR})
   endif()


### PR DESCRIPTION
I'm trying to get tblis adopted by conda-forge. If that succeeds, then it would be nice to have an option to build this package using an externally provided tblis. That way, installation would be more convenient.

I will do some testing if tblis is accepted into conda-forge. Otherwise there's no point in merging this pull request.