### PR TITLE
Wrappers for additional tblis functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 64"]
+build-backend = "setuptools.build_meta"

--- a/pyscf/tblis_einsum/CMakeLists.txt
+++ b/pyscf/tblis_einsum/CMakeLists.txt
@@ -30,25 +30,30 @@ if (CMAKE_COMPILER_IS_GNUCC) # Does it skip the link flag on old OsX?
   endif()
 endif()
 
-# See also https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/RPATH-handling
-if (WIN32)
-  #?
-elseif (APPLE)
-  set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
-  set(CMAKE_INSTALL_RPATH "@loader_path")
-  set(CMAKE_BUILD_RPATH "@loader_path")
-else ()
-  set(CMAKE_SKIP_BUILD_RPATH  True)
-  set(CMAKE_BUILD_WITH_INSTALL_RPATH True)
-  set(CMAKE_INSTALL_RPATH "\$ORIGIN")
-endif ()
+option(VENDOR_TBLIS "Download and build tblis" on)
+
+if(VENDOR_TBLIS)
+  # The following is needed because TBLIS will be installed in the same folder
+  # as the built CPython extension.
+  # See also https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/RPATH-handling
+  if (WIN32)
+    #?
+  elseif (APPLE)
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+    set(CMAKE_INSTALL_RPATH "@loader_path")
+    set(CMAKE_BUILD_RPATH "@loader_path")
+  else ()
+    set(CMAKE_SKIP_BUILD_RPATH  True)
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH True)
+    set(CMAKE_INSTALL_RPATH "\$ORIGIN")
+  endif ()
+endif()
 
 set(C_LINK_TEMPLATE "<CMAKE_C_COMPILER> <CMAKE_SHARED_LIBRARY_C_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>")
 set(CXX_LINK_TEMPLATE "<CMAKE_CXX_COMPILER> <CMAKE_SHARED_LIBRARY_CXX_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>")
 
 add_library(tblis_einsum SHARED as_einsum.cxx)
 
-option(VENDOR_TBLIS "Download and build tblis" on)
 set_target_properties(tblis_einsum PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}
   COMPILE_FLAGS "-std=c++11")

--- a/pyscf/tblis_einsum/__init__.py
+++ b/pyscf/tblis_einsum/__init__.py
@@ -1,3 +1,3 @@
 __version__ = '0.1.5'
 
-from .tblis_einsum import contract
+from .tblis_einsum import contract, tensor_add, tensor_mult, tensor_dot

--- a/pyscf/tblis_einsum/as_einsum.cxx
+++ b/pyscf/tblis_einsum/as_einsum.cxx
@@ -1,4 +1,5 @@
 #include <stddef.h>
+#include <stdlib.h>
 #include <tblis/tblis.h>
 using namespace tblis;
 
@@ -42,7 +43,7 @@ static void _as_tensor(tblis_tensor *t, void *data, int dtype, int ndim,
 }
 
 extern "C" {
-void as_einsum(void *data_A, int ndim_A, ptrdiff_t *shape_A, ptrdiff_t *strides_A, char *descr_A,
+void tensor_mult(void *data_A, int ndim_A, ptrdiff_t *shape_A, ptrdiff_t *strides_A, char *descr_A,
                void *data_B, int ndim_B, ptrdiff_t *shape_B, ptrdiff_t *strides_B, char *descr_B,
                void *data_C, int ndim_C, ptrdiff_t *shape_C, ptrdiff_t *strides_C, char *descr_C,
                int dtype, void *alpha, void *beta)
@@ -53,5 +54,47 @@ void as_einsum(void *data_A, int ndim_A, ptrdiff_t *shape_A, ptrdiff_t *strides_
     _as_tensor(&C, data_C, dtype, ndim_C, shape_C, strides_C, beta);
 
     tblis_tensor_mult(NULL, NULL, &A, descr_A, &B, descr_B, &C, descr_C);
+}
+
+
+void tensor_add(void *data_A, int ndim_A, ptrdiff_t *shape_A, ptrdiff_t *strides_A, char *descr_A,
+               void *data_B, int ndim_B, ptrdiff_t *shape_B, ptrdiff_t *strides_B, char *descr_B,
+               int dtype, void *alpha, void *beta)
+{
+    tblis_tensor A, B;
+    _as_tensor(&A, data_A, dtype, ndim_A, shape_A, strides_A, alpha);
+    _as_tensor(&B, data_B, dtype, ndim_B, shape_B, strides_B, beta);
+
+    tblis_tensor_add(NULL, NULL, &A, descr_A, &B, descr_B);
+}
+
+void tensor_dot(void *data_A, int ndim_A, ptrdiff_t *shape_A, ptrdiff_t *strides_A, char *descr_A,
+               void *data_B, int ndim_B, ptrdiff_t *shape_B, ptrdiff_t *strides_B, char *descr_B,
+               int dtype, void *result)
+{
+    tblis_tensor A, B;
+    tblis_scalar s;
+    _as_tensor(&A, data_A, dtype, ndim_A, shape_A, strides_A, NULL);
+    _as_tensor(&B, data_B, dtype, ndim_B, shape_B, strides_B, NULL);
+
+    tblis_tensor_dot(NULL, NULL, &A, descr_A, &B, descr_B, &s);
+
+    ssize_t bytes;
+    switch(dtype) {
+        case TYPE_SINGLE:
+            bytes = sizeof(float);
+            break;
+        case TYPE_DOUBLE:
+            bytes = sizeof(double);
+            break;
+        case TYPE_SCOMPLEX:
+            bytes = sizeof(scomplex);
+            break;
+        case TYPE_DCOMPLEX:
+            bytes = sizeof(dcomplex);
+            break;
+    }
+
+    memcpy(result, &s.data, bytes);
 }
 }

--- a/pyscf/tblis_einsum/tests/test_einsum.py
+++ b/pyscf/tblis_einsum/tests/test_einsum.py
@@ -134,7 +134,6 @@ class KnownValues(unittest.TestCase):
         b = np.random.random((3,3,3,3))
         c0 = np.transpose(a, (1,2,3,0)) + b
         tensor_add(a, 'lijk', b, 'ijkl')
-        print(abs(c0-b).max())
         self.assertTrue(abs(c0-b).max() < 1e-14)
 
     def test_tensor_add_scaled(self):
@@ -145,6 +144,13 @@ class KnownValues(unittest.TestCase):
         c0 = alpha*a + beta*b
         tensor_add(a, 'ijkl', b, 'ijkl', alpha=alpha, beta=beta)
         self.assertTrue(abs(c0-b).max() < 1e-14)
+
+    def test_tensor_dot(self):
+        a = np.random.random((3,3,3,3))
+        b = np.random.random((3,3,3,3))
+        ans = np.einsum('lijk,ijkl->', a, b)
+        ans2 = tensor_dot(a, 'lijk', b, 'ijkl')
+        self.assertTrue(abs(ans-ans2) < 1e-14)
 
 
 

--- a/pyscf/tblis_einsum/tests/test_einsum.py
+++ b/pyscf/tblis_einsum/tests/test_einsum.py
@@ -1,6 +1,6 @@
 import unittest
 import numpy as np
-from pyscf.tblis_einsum import tblis_einsum
+from pyscf.tblis_einsum import tblis_einsum, tensor_add, tensor_mult, tensor_dot
 
 def setUpModule():
     global bak
@@ -128,6 +128,24 @@ class KnownValues(unittest.TestCase):
         res_np = np.einsum("ij,jk->k", c, c)
         res_tblis = tblis_einsum.contract("ij,jk->k", c, c)
         self.assertTrue (abs(res_np - res_tblis).max() < 1e-13)
+
+    def test_tensor_add(self):
+        a = np.random.random((3,3,3,3))
+        b = np.random.random((3,3,3,3))
+        c0 = np.transpose(a, (1,2,3,0)) + b
+        tensor_add(a, 'lijk', b, 'ijkl')
+        print(abs(c0-b).max())
+        self.assertTrue(abs(c0-b).max() < 1e-14)
+
+    def test_tensor_add_scaled(self):
+        a = np.random.random((7,1,3,4))
+        b = np.random.random((7,1,3,4))
+        alpha = 2.0
+        beta = 3.0
+        c0 = alpha*a + beta*b
+        tensor_add(a, 'ijkl', b, 'ijkl', alpha=alpha, beta=beta)
+        self.assertTrue(abs(c0-b).max() < 1e-14)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Pip 25 [will refuse to do](https://github.com/pypa/pip/issues/11457) editable installs without a pyproject.toml file. I added a minimal one according to the recommendations in the linked issue.
2. Added wrappers for `tblis_tensor_add` and `tblis_tensor_dot`
3. Renamed the C function `as_einsum` to `tensor_mult`. This does not change the public API, but I can drop this point and keep the original name if some code depends on it.
4. Fixed RPATH settings when external tblis is linked.